### PR TITLE
refactor: extract landing styles to external file

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,74 +9,7 @@
   <!-- Notable font for the wordmark -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Notable&display=swap" rel="stylesheet">
-  <style>
-    :root{
-      --bg:#0a0a0d;
-      --panel:#0c0d13;
-      --brandScale: 1;
-      --brandTopPct: 50;
-      --brandTranslateY: -50;
-      --fillAlpha: 1;
-    }
-    * { box-sizing: border-box; }
-    html, body { height: 100%; }
-    html { scroll-behavior: smooth; }
-    body { margin: 0; background: var(--bg); color: #fff; }
-
-    /* Layer stack */
-    #gl, #matte, #grain, #cutout { position: fixed; inset: 0; width: 100vw; height: 100vh; display: block; pointer-events: none; }
-    #gl    { z-index: 0; }
-    #matte { z-index: 1; }
-    main   { position: relative; z-index: 2; }
-    #cutout{ z-index: 3; }
-    #grain { z-index: 4; }
-    .ui    { position: fixed; inset: 0; z-index: 5; pointer-events: none; }
-
-    .brandWrap {
-      position: absolute; left: 50%;
-      top: calc(var(--brandTopPct) * 1%);
-      transform: translate(-50%, calc(var(--brandTranslateY) * 1%)) scale(var(--brandScale));
-      transform-origin: top center;
-      will-change: transform, top;
-    }
-    .brand {
-      font-family: "Notable", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-      color: rgba(255,255,255,var(--fillAlpha));
-      text-transform: uppercase; line-height: 0.9; letter-spacing: 0.02em;
-      font-size: clamp(64px, 16vw, 220px); white-space: nowrap; user-select: none;
-    }
-
-    section.page { min-height: 100vh; display: grid; place-items: center; padding: 8vmin 5vmin; background: transparent; }
-    .page-hero { background: transparent; }
-    .page-scroll { background: transparent; padding-top: clamp(140px, 20vh, 240px); }
-
-    .card {
-      max-width: 1000px; width: min(92vw, 1000px);
-      border-radius: 24px; padding: 32px clamp(20px, 4vw, 48px);
-      background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.02));
-      border: 1px solid rgba(255,255,255,0.08);
-      box-shadow: 0 20px 60px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.02);
-      backdrop-filter: blur(6px);
-    }
-    .card h2 { margin: 0 0 12px; font: 700 clamp(20px, 3.6vw, 40px)/1 "Notable", system-ui; }
-    .card p { margin: 0; opacity: 0.9; font: 500 clamp(14px, 1.6vw, 18px)/1.5 system-ui, sans-serif; }
-
-    .scroll-cue { position: absolute; left: 50%; bottom: 24px; transform: translateX(-50%); opacity: .7; font: 600 12px/1.2 system-ui; letter-spacing: .2em; text-transform: uppercase; }
-    .scroll-cue::after { content: "\2193"; display: inline-block; margin-left: .6em; animation: bob 1.4s ease-in-out infinite; }
-    @keyframes bob { 0%,100%{ transform: translateY(0); } 50%{ transform: translateY(6px); } }
-
-    /* Scroller canvas host */
-    #scroll-root {
-      width: 100vw; height: 100vh; display: grid; place-items: center;
-      position: relative;
-    }
-    #canvas {
-      width: 92vw; height: 80vh; display:block;
-      border-radius: 16px;
-      box-shadow: 0 30px 80px rgba(0,0,0,0.45);
-      background: #000;
-    }
-  </style>
+  <link rel="stylesheet" href="/landing.css">
 </head>
 <body>
   <!-- Landing: WebGL shader background + matte/cutouts -->

--- a/public/landing.css
+++ b/public/landing.css
@@ -1,0 +1,67 @@
+    :root{
+      --bg:#0a0a0d;
+      --panel:#0c0d13;
+      --brandScale: 1;
+      --brandTopPct: 50;
+      --brandTranslateY: -50;
+      --fillAlpha: 1;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    html { scroll-behavior: smooth; }
+    body { margin: 0; background: var(--bg); color: #fff; }
+
+    /* Layer stack */
+    #gl, #matte, #grain, #cutout { position: fixed; inset: 0; width: 100vw; height: 100vh; display: block; pointer-events: none; }
+    #gl    { z-index: 0; }
+    #matte { z-index: 1; }
+    main   { position: relative; z-index: 2; }
+    #cutout{ z-index: 3; }
+    #grain { z-index: 4; }
+    .ui    { position: fixed; inset: 0; z-index: 5; pointer-events: none; }
+
+    .brandWrap {
+      position: absolute; left: 50%;
+      top: calc(var(--brandTopPct) * 1%);
+      transform: translate(-50%, calc(var(--brandTranslateY) * 1%)) scale(var(--brandScale));
+      transform-origin: top center;
+      will-change: transform, top;
+    }
+    .brand {
+      font-family: "Notable", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      color: rgba(255,255,255,var(--fillAlpha));
+      text-transform: uppercase; line-height: 0.9; letter-spacing: 0.02em;
+      font-size: clamp(64px, 16vw, 220px); white-space: nowrap; user-select: none;
+    }
+
+    section.page { min-height: 100vh; display: grid; place-items: center; padding: 8vmin 5vmin; background: transparent; }
+    .page-hero { background: transparent; }
+    .page-scroll { background: transparent; padding-top: clamp(140px, 20vh, 240px); }
+
+    .card {
+      max-width: 1000px; width: min(92vw, 1000px);
+      border-radius: 24px; padding: 32px clamp(20px, 4vw, 48px);
+      background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.02));
+      border: 1px solid rgba(255,255,255,0.08);
+      box-shadow: 0 20px 60px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.02);
+      backdrop-filter: blur(6px);
+    }
+    .card h2 { margin: 0 0 12px; font: 700 clamp(20px, 3.6vw, 40px)/1 "Notable", system-ui; }
+    .card p { margin: 0; opacity: 0.9; font: 500 clamp(14px, 1.6vw, 18px)/1.5 system-ui, sans-serif; }
+
+    .scroll-cue { position: absolute; left: 50%; bottom: 24px; transform: translateX(-50%); opacity: .7; font: 600 12px/1.2 system-ui; letter-spacing: .2em; text-transform: uppercase; }
+    .scroll-cue::after { content: "\2193"; display: inline-block; margin-left: .6em; animation: bob 1.4s ease-in-out infinite; }
+    @keyframes bob { 0%,100%{ transform: translateY(0); } 50%{ transform: translateY(6px); } }
+
+    /* Scroller canvas host */
+    #scroll-root {
+      width: 100vw; height: 100vh; display: grid; place-items: center;
+      position: relative;
+    }
+    #canvas {
+      width: 92vw; height: 80vh; display:block;
+      border-radius: 16px;
+      box-shadow: 0 30px 80px rgba(0,0,0,0.45);
+      background: #000;
+    }
+


### PR DESCRIPTION
## Summary
- move inline landing page styles into `public/landing.css`
- reference the external stylesheet from `index.html`

## Testing
- `npm run dev -- --clearScreen false`
- `curl -I http://localhost:5173/landing.css`


------
https://chatgpt.com/codex/tasks/task_e_689d0fa4b7388331bc5d5cc58f0185c7