### PR TITLE
refactor: move rendering class to core

### DIFF
--- a/src/core/rendering.js
+++ b/src/core/rendering.js
@@ -1,6 +1,5 @@
 
 import * as THREE from "three";
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 
 export class Rendering {
   constructor(canvas, palette) {
@@ -84,6 +83,3 @@ export class Rendering {
     this.vp.scene = this.getViewSizeAtDepth();
   }
 }
-
-// let a = new Demo(GL.canvas);
-// a.init();

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -1,6 +1,6 @@
 import "./style.css"
 import { gsap } from "gsap"
-import { Rendering } from "./rendering.js"
+import { Rendering } from "../core/rendering.js"
 import * as THREE from "three";
 
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"


### PR DESCRIPTION
## Summary
- relocate `Rendering` class to `src/core/rendering.js`
- update demo to import `Rendering` from core

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1caa8aec8331a040be59e1d83a72