### PR TITLE
Expand landing scroll canvas to full viewport

### DIFF
--- a/public/landing.css
+++ b/public/landing.css
@@ -36,7 +36,8 @@
 
     section.page { min-height: 100vh; display: grid; place-items: center; padding: 8vmin 5vmin; background: transparent; }
     .page-hero { background: transparent; }
-    .page-scroll { background: transparent; padding-top: clamp(140px, 20vh, 240px); }
+    .page-scroll { background: transparent; padding-top: 0; }
+    .page.page-scroll { padding-left: 0; padding-right: 0; }
 
     .card {
       max-width: 1000px; width: min(92vw, 1000px);
@@ -55,11 +56,11 @@
 
     /* Scroller canvas host */
     #scroll-root {
-      width: 100vw; height: 100vh; display: grid; place-items: center;
+      width: 100%; height: 100vh; display: grid; place-items: center;
       position: relative;
     }
     #canvas {
-      width: 92vw; height: 80vh; display:block;
+      width: 100vw; height: 100vh; display:block;
       border-radius: 16px;
       box-shadow: 0 30px 80px rgba(0,0,0,0.45);
       background: #000;


### PR DESCRIPTION
## Summary
- Remove top padding so PolyCarbon cutout stays centered at top when entering scroll section
- Stretch the scroll canvas to cover the entire viewport and ensure scroll root fits container width

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d282b274c83318b828932c56aa1fc